### PR TITLE
Update authnrequest.xml

### DIFF
--- a/src/code-samples/authnrequest.xml
+++ b/src/code-samples/authnrequest.xml
@@ -7,14 +7,14 @@
     AssertionConsumerServiceURL="http://spid.serviceprovider.it"
     ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
     AttributeConsumingServiceIndex="1">
-    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-        [...]
-    </ds:Signature>
     <saml:Issuer
         NameQualifier="http://spid.serviceprovider.it"
         Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">
         spid-sp
     </saml:Issuer>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        [...]
+    </ds:Signature>
     <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" />
     <samlp:RequestedAuthnContext Comparison="exact">
         <saml:AuthnContextClassRef>


### PR DESCRIPTION
In base ai test eseguiti durante l'hackathon Hack Developers Italia, la firma va inserita dopo l'issuer.