### PR TITLE
Update metadata.rst

### DIFF
--- a/metadata.rst
+++ b/metadata.rst
@@ -97,7 +97,7 @@ Le caratteristiche del Service Provider devono essere definite attraverso metada
 
     * Deve essere presente l'elemento ``<KeyDescriptor>`` contenenete il certificato della corrispondente chiave pubblica dell'entità, utile per la verifica della firma dei messaggi prodotti da tale entità nelle sue interazioni con le altre (SAML-Metadata, par. 2.4.1.1);
     * Deve essere presente l'elemento ``<Signature>`` riportante la firma sui metadata. La firma deve essere prodotta secondo il profilo specificato per SAML (SAML-Metadata, cap. 3) utilizzando chiavi RSA almeno a 1024 bit e algoritmo di digest SHA-256 o superiore;
-    * Deve essere presente l’elemento ``<SPSSODescriptor>`` riportante i seguenti attributi:
+    * Deve essere presente un solo elemento ``<SPSSODescriptor>`` riportante i seguenti attributi:
 
         * ``protocolSupportEnumeration``: che enumera, separati da uno spazio, gli URI associati ai protocolli supportati dall’entità (poiché si tratta di un’entità SAML 2.0, deve indicare almeno il valore del relativo protocollo: ``urn:oasis:names:tc:SAML:2.0:protocol``);
         * ``AuthnRequestSigned``: valorizzato ``true`` attributo con valore booleano che esprime il requisito che le richieste di autenticazione inviate dal Service Provider siano firmate;


### PR DESCRIPTION
Chiarifica meglio il fatto che è previsto un solo elemento SPSSODescriptor, diversamente da quanto previsto dalle specifiche SAML2 (cfr. https://forum.italia.it/t/un-ente-un-metadato-piu-spssodescriptor/17228 e https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf riga 343)